### PR TITLE
using ec2 instead of fargate to deploy dispute tools

### DIFF
--- a/environments/production/main.tf
+++ b/environments/production/main.tf
@@ -53,6 +53,7 @@ variable "tools_contact_email" {
 
 variable "tools_image_name" {
   description = "Full repository URI reference to image name to deploy"
+  default     = "debtcollective/dispute-tools:latest"
 }
 
 variable "tools_discourse_api_username" {
@@ -192,12 +193,13 @@ module "mediawiki" {
 }
 
 module "dispute_tools" {
-  source          = "./modules/compute/services/dispute-tools"
-  environment     = "${var.environment}"
-  vpc_id          = "${module.vpc.id}"
-  subnets         = "${module.vpc.public_subnet_ids}"
-  subnet_id       = "${element(module.vpc.public_subnet_ids, 0)}"
-  security_groups = "${module.vpc.ec2_security_group_id}"
+  source              = "./modules/compute/services/dispute-tools"
+  environment         = "${var.environment}"
+  vpc_id              = "${module.vpc.id}"
+  subnet_ids          = "${module.vpc.public_subnet_ids}"
+  ec2_security_groups = "${module.vpc.ec2_security_group_id}"
+  elb_security_groups = "${module.vpc.elb_security_group_id}"
+  key_name            = "development-tdc"
 
   sso_endpoint = "https://community.debtsyndicate.org/sso/sso_provider"
   sso_secret   = "${var.sso_secret}"
@@ -258,8 +260,8 @@ resource "aws_route53_record" "dispute_tools" {
   type    = "A"
 
   alias {
-    name                   = "${module.dispute_tools.alb_dns_name}"
-    zone_id                = "${module.dispute_tools.alb_zone_id}"
+    name                   = "${module.dispute_tools.lb_dns_name}"
+    zone_id                = "${module.dispute_tools.lb_zone_id}"
     evaluate_target_health = true
   }
 }

--- a/modules/compute/services/discourse/web.yml
+++ b/modules/compute/services/discourse/web.yml
@@ -43,3 +43,10 @@ hooks:
           - git clone https://github.com/angusmcleod/discourse-events.git
           - git clone https://github.com/angusmcleod/discourse-locations.git
           - git clone https://github.com/debtcollective/discourse-theme.git
+
+    # Make backups work with RDS
+    - exec:
+        cd: $home
+        cmd:
+          - apt-get -y install postgresql-9.6
+          - ln -s -f /usr/lib/postgresql/9.6/bin/pg_dump /usr/bin/pg_dump

--- a/modules/compute/services/dispute-tools/bucket-policy.json
+++ b/modules/compute/services/dispute-tools/bucket-policy.json
@@ -4,10 +4,7 @@
     {
       "Sid": "VisualEditor0",
       "Effect": "Allow",
-      "Action": [
-        "s3:PutObjectAcl",
-        "s3:PutObject"
-      ],
+      "Action": "*",
       "Resource": [
         "${resource_arn}/*",
         "${resource_arn}"

--- a/modules/compute/services/dispute-tools/container-definitions.json
+++ b/modules/compute/services/dispute-tools/container-definitions.json
@@ -1,14 +1,13 @@
 [
   {
-    "memory": 300,
+    "image": "${image_name}",
+    "name": "${container_name}",
+    "memoryReservation": 256,
     "portMappings": [
       {
-        "hostPort": 80,
-        "containerPort": 80
+        "containerPort": 8080
       }
     ],
-    "networkMode": "awsvpc",
-    "command": [],
     "environment": [
       {
         "name": "SSO_ENDPOINT",
@@ -80,7 +79,7 @@
       },
       {
         "name": "AWS_UPLOAD_BUCKET",
-        "value": "tds-tools-${environment}"
+        "value": "${aws_bucket_name}"
       },
       {
         "name": "AWS_ACCESS_KEY_ID",
@@ -119,7 +118,13 @@
         "value": "${discourse_api_username}"
       }
     ],
-    "image": "${image_name}",
-    "name": "tds-dispute-tools"
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group" : "${log_group}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "${container_name}"
+      }
+    }
   }
 ]

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -228,13 +228,6 @@ resource "aws_security_group" "ec2" {
     security_groups = ["${aws_security_group.elb.id}"]
   }
 
-  ingress {
-    from_port       = 32768
-    to_port         = 61000
-    protocol        = "tcp"
-    security_groups = ["${aws_security_group.elb.id}"]
-  }
-
   # NRPE & SNMP for Security Monitoring
   ingress {
     from_port   = 5666

--- a/modules/utils/launch_configuration/user_data.sh
+++ b/modules/utils/launch_configuration/user_data.sh
@@ -1,3 +1,17 @@
 #!/bin/bash
+# Register instance with ECS cluster
 echo ECS_CLUSTER=${cluster_name} > /etc/ecs/ecs.config
 export ENVIRONMENT=${environment}
+
+# Tools
+sudo yum install htop -y
+
+# Create swap file
+sudo fallocate -l 1G /swapfile
+ls -lh /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+echo 'vm.swappiness=10' | sudo tee -a /etc/sysctl.conf
+echo 'vm.vfs_cache_pressure=50' | sudo tee -a /etc/sysctl.conf


### PR DESCRIPTION
This PR refactors `dispute_tools` module to use EC2 instead of Fargate. It also fixes discourse backups by updating the `pg_dump` library to match the version of postgres we are using in RDS