### PR TITLE
using redis:4 to match version used in dev

### DIFF
--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -39,6 +39,8 @@ variable "tools_stripe_publishable" {}
 variable "tools_db_pool_min" {}
 variable "tools_db_pool_max" {}
 
+variable "tools_sentry_endpoint" {}
+
 variable "tools_sender_email" {
   default = "admin@debtsyndicate.org"
 }
@@ -208,7 +210,7 @@ module "dispute_tools" {
 
   google_maps_api_key = "${var.tools_gmaps_api_key}"
 
-  sentry_endpoint = ""
+  sentry_endpoint = "${var.tools_sentry_endpoint}"
 
   db_connection_string = "postgres://${var.db_username}:${var.db_password}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/dispute_tools_${var.environment}"
   db_pool_min          = "${var.tools_db_pool_min}"

--- a/modules/compute/services/dispute-tools/container-definitions.json
+++ b/modules/compute/services/dispute-tools/container-definitions.json
@@ -1,6 +1,6 @@
 [
   {
-    "image": "redis:alpine",
+    "image": "redis:4",
     "name": "${container_name}_redis",
     "memoryReservation": 128
   },

--- a/modules/compute/services/dispute-tools/main.tf
+++ b/modules/compute/services/dispute-tools/main.tf
@@ -7,7 +7,7 @@ variable "environment" {
 
 variable "image_name" {
   description = "Docker image for ECS task"
-  default     = "183550513269.dkr.ecr.us-east-1.amazonaws.com/dispute-tools:latest"
+  default     = "debtcollective/dispute-tools:latest"
 }
 
 variable "subnet_ids" {


### PR DESCRIPTION
This PR locks the redis version for dispute-tools and adds `tools_sentry_endpoint` as a variable

Related to debtcollective/parent#211