### PR TITLE
Add Discourse SSO env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # debtcollective terraform
 
-This is the terraform recipes we use to generate our production
-environment.
+This is the terraform recipes we use to generate our production environment. This is in phase out mode and will be replaced by [infra](https://github.com/debtcollective/infra).
 
 ## Installation
 
-First you will need to install [Terraform](https://www.terraform.io/intro/getting-started/install.html). If you are on OSX use [Homebrew](https://brew.sh/) to do this. If you don't have homebrew installed, [install it first](https://brew.sh/)
+We need to run a specific Terraform version, this repo is compatible with v0.11.14. To install it use [tfenv](https://github.com/tfutils/tfenv)
 
 ```bash
-brew install terraform
+brew install tfenv
+tfenv install 0.11.14
 ```
 
 Then follow these steps to init your environment

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the terraform recipes we use to generate our production environment. Thi
 
 ## Installation
 
-We need to run a specific Terraform version, this repo is compatible with v0.11.14. To install it use [tfenv](https://github.com/tfutils/tfenv)
+This repo is compatible with Terraform v0.11.14. To install this specific version use [tfenv](https://github.com/tfutils/tfenv)
 
 ```bash
 brew install tfenv

--- a/environments/production/Makefile
+++ b/environments/production/Makefile
@@ -22,7 +22,7 @@ apply: print_current_env update
 	aws s3 cp key_pair_$(ENVIRONMENT) s3://$(BUCKET)/$(ENVIRONMENT)/key_pair_$(ENVIRONMENT)
 
 plan: print_current_env update
-	terraform plan -input=false -refresh=true -module-depth=-1
+	terraform plan -input=false -refresh=true
 
 output: print_current_env
 	terraform output

--- a/environments/production/Makefile
+++ b/environments/production/Makefile
@@ -22,7 +22,7 @@ apply: print_current_env update
 	aws s3 cp key_pair_$(ENVIRONMENT) s3://$(BUCKET)/$(ENVIRONMENT)/key_pair_$(ENVIRONMENT)
 
 plan: print_current_env update
-	terraform plan -input=false -refresh=true
+	terraform plan -input=false -refresh=true -module-depth=-1
 
 output: print_current_env
 	terraform output

--- a/environments/production/main.tf
+++ b/environments/production/main.tf
@@ -2,7 +2,8 @@
  * Config
  */
 provider "aws" {
-  region = "us-east-1"
+  region  = "us-east-1"
+  version = "~> 1.0"
 }
 
 /*
@@ -53,6 +54,8 @@ variable "landing" {
  * Remote State
  */
 terraform {
+  required_version = "0.11.14"
+
   backend "s3" {
     bucket = "tdc-terraform"
     region = "us-east-1"
@@ -85,7 +88,7 @@ resource "aws_db_instance" "postgres" {
   identifier        = "postgres-${var.environment}"
   allocated_storage = "30"
   engine            = "postgres"
-  engine_version    = "10.5"
+  engine_version    = "10.6"
   instance_class    = "db.t2.micro"
   name              = "discourse_${var.environment}"
   username          = "${var.db_username}"

--- a/modules/compute/services/discourse/main.tf
+++ b/modules/compute/services/discourse/main.tf
@@ -154,7 +154,7 @@ resource "random_string" "discourse_sso_jwt_secret" {
 resource "aws_ssm_parameter" "discourse_sso_jwt_secret" {
   name  = "/${var.environment}/services/discourse/sso_jwt_secret"
   type  = "SecureString"
-  value = random_string.discourse_sso_jwt_secret.result
+  value = "${random_string.discourse_sso_jwt_secret.result}"
 }
 
 // Discourse configuration

--- a/modules/compute/services/discourse/main.tf
+++ b/modules/compute/services/discourse/main.tf
@@ -195,6 +195,25 @@ resource "aws_s3_bucket" "uploads" {
   bucket = "community-uploads-${var.environment}"
   acl    = "public-read"
 
+  cors_rule {
+    allowed_headers = ["Authorization"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3000
+  }
+
+  lifecycle_rule {
+    id      = "purge_tombstone"
+    enabled = true
+
+    prefix = "tombstone/"
+
+    expiration {
+      days                         = 90
+      expired_object_delete_marker = false
+    }
+  }
+
   tags {
     Terraform   = true
     Name        = "community-uploads-${var.environment}"

--- a/modules/compute/services/discourse/main.tf
+++ b/modules/compute/services/discourse/main.tf
@@ -146,6 +146,17 @@ data "template_file" "user_data" {
   template = "${file("${path.module}/user_data.sh")}"
 }
 
+// Generate sso_jwt_secret
+resource "random_string" "discourse_sso_jwt_secret" {
+  length = 64
+}
+
+resource "aws_ssm_parameter" "discourse_sso_jwt_secret" {
+  name  = "/${var.environment}/services/discourse/sso_jwt_secret"
+  type  = "SecureString"
+  value = random_string.discourse_sso_jwt_secret.result
+}
+
 // Discourse configuration
 data "template_file" "discourse" {
   template = "${file("${path.module}/web.yml")}"
@@ -167,6 +178,9 @@ data "template_file" "discourse" {
     discourse_developer_emails          = "${var.discourse_developer_emails}"
     discourse_hostname                  = "${var.discourse_hostname}"
     discourse_letsencrypt_account_email = "${var.discourse_letsencrypt_account_email}"
+    discourse_sso_jwt_secret            = "${aws_ssm_parameter.discourse_sso_jwt_secret.value}"
+    discourse_sso_cookie_name           = "tdc_auth_${var.environment}"
+    discourse_sso_cookie_domain         = ".${var.domain}"
 
     discourse_s3_region            = "${aws_s3_bucket.uploads.region}"
     discourse_s3_access_key_id     = "${aws_iam_access_key.discourse.id}"

--- a/modules/compute/services/discourse/web.yml
+++ b/modules/compute/services/discourse/web.yml
@@ -18,6 +18,9 @@ env:
   DISCOURSE_SMTP_PASSWORD: "${discourse_smtp_password}"
   DISCOURSE_SMTP_PORT: "${discourse_smtp_port}"
   DISCOURSE_SMTP_USER_NAME: "${discourse_smtp_username}"
+  DISCOURSE_SSO_COOKIE_DOMAIN: "${discourse_sso_cookie_domain}"
+  DISCOURSE_SSO_COOKIE_NAME: "${discourse_sso_cookie_name}"
+  DISCOURSE_SSO_JWT_SECRET: "${discourse_sso_jwt_secret}"
   LANG: en_US.UTF-8
   LETSENCRYPT_ACCOUNT_EMAIL: "${discourse_letsencrypt_account_email}"
   USE_DB_S3_CONFIG: true


### PR DESCRIPTION
**What:** Add Discourse SSO env variables

**Why:** To add configuration required by https://github.com/debtcollective/discourse-debtcollective-sso/commit/e57388783ace267250529f29aa01ddeee94f3d44

**How:**

- Lock terraform version to 0.11.14, this codebase doesn't work with terraform 0.12+
- Lock aws version to 1.x
- Add info on how to install terraform using tfenv
- Inject env variables to Discourse yml